### PR TITLE
Depend on eos-metrics GIR 0.2.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,8 @@ Package: eos-gates
 Architecture: all
 Section: non-free/utils
 Priority: extra
-Depends: gir1.2-glib-2.0,
+Depends: gir1.2-eosmetrics-0 (>= 0.2.0),
+         gir1.2-glib-2.0,
          gir1.2-gtk-3.0,
          gjs,
          ${misc:Depends}


### PR DESCRIPTION
The package was missing a dependency on the EosMetrics GIR; also in order
to prevent it from upgrading before the newly organized library is
available, we depend on 0.2.0 or later.

[endlessm/eos-sdk#2043]
