### PR TITLE
Switched to ref-counted event recorder.

### DIFF
--- a/src/eos_gates_linux_package.js
+++ b/src/eos_gates_linux_package.js
@@ -11,10 +11,9 @@ const EosGates = imports.eos_gates;
 // the package.
 const LINUX_PACKAGE_OPENED = '0bba3340-52e3-41a2-854f-e6ed36621379';
 
-function recordMetrics(packageFile) {
-    let recorder = EosMetrics.EventRecorder.get_default();
-    let data = new GLib.Variant('s', packageFile.packagePath);
-    recorder.record_event(LINUX_PACKAGE_OPENED, data);
+function recordPackageOpen(packageFile) {
+    let packageFilepath = new GLib.Variant('s', packageFile.packagePath);
+    this._eventRecorder.record_event(LINUX_PACKAGE_OPENED, packageFilepath);
 }
 
 const EosGatesLinuxPackage = new Lang.Class({
@@ -26,6 +25,10 @@ const EosGatesLinuxPackage = new Lang.Class({
     _getMainErrorMessage: function() {
         let escapedDisplayName = GLib.markup_escape_text(this._launchedFile.displayName, -1);
         return _("Sorry, you can't install <b>%s</b> on Endless.").format(escapedDisplayName);
+    },
+
+    _init: function() {
+        this._eventRecorder = new EosMetrics.EventRecorder();
     },
 });
 
@@ -54,7 +57,7 @@ function main(argv) {
 	return 1;
     }
 
-    recordMetrics(packageFile);
+    recordPackageOpen(packageFile);
 
     let app = new EosGatesLinuxPackage(packageFile);
     return app.run(null);

--- a/src/eos_gates_windows.js
+++ b/src/eos_gates_windows.js
@@ -17,10 +17,9 @@ const WHITELISTED_APPS = [
 // argv that was passed to the application.
 const WINDOWS_APP_OPENED = 'cf09194a-3090-4782-ab03-87b2f1515aed';
 
-function recordMetrics(process) {
-    let recorder = EosMetrics.EventRecorder.get_default();
-    let data = new GLib.Variant('as', process.argv);
-    recorder.record_event(WINDOWS_APP_OPENED, data);
+function recordWindowsAppOpen(process) {
+    let args = new GLib.Variant('as', process.argv);
+    this._eventRecorder.record_event(WINDOWS_APP_OPENED, args);
 }
 
 function spawnUnderWine(process) {
@@ -79,6 +78,10 @@ const EosGatesWindows = new Lang.Class({
         let escapedDisplayName = GLib.markup_escape_text(this._launchedFile.displayName, -1);
         return _("Sorry, you can't run <b>%s</b> on Endless.").format(escapedDisplayName);
     },
+
+    _init: function() {
+        this._eventRecorder = new EosMetrics.EventRecorder();
+    },
 });
 
 function getProcess(argv) {
@@ -106,7 +109,7 @@ function main(argv) {
 	return 1;
     }
 
-    recordMetrics(process);
+    recordWindowsAppOpen(process);
 
     readWhitelist();
     if (isWhitelisted(process)) {


### PR DESCRIPTION
The singleton event recorder is deprecated because it never flushes
events to DBus. The ref-counted event recorder should be used going
forward.

[endlessm/eos-sdk#2906]