### PR TITLE
replacements: reword eos-installer.desktop strings

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -16,8 +16,8 @@ function generateEndlessInstallerEntry() {
         entry.overrideHelpMessage = _("You are already running Endless OS from live media");
         entry.desktopInfo = desktopInfo,
         entry.replacementInfo = {
-            appName: _("Endless OS Installer"),
-            description: _("You can install Endless OS by running the Endless OS Installer.")
+            appName: _("Reformat with Endless OS"),
+            description: _("You can reformat your computer with Endless OS. If you have Windows installed and want to keep it, reboot to Windows and download the Endless Installer for Windows.")
         }
     }
 


### PR DESCRIPTION
We call eos-installer, which is destructive, "Reformat" on the desktop
and "Reformat with Endless OS" in places with more space. We call the
Windows tool, which is not destructive, the Endless Installer for
Windows.

https://phabricator.endlessm.com/T15502