### PR TITLE
T20322: install Steam from flathub instead of eos-apps

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -71,7 +71,7 @@ function definitions() {
                  linux: /steam.*/i
             },
             appName: _("Steam"),
-            flatpakInfo: { remote: 'eos-apps', id: 'com.valvesoftware.Steam' }
+            flatpakInfo: { remote: 'flathub', id: 'com.valvesoftware.Steam' }
         },
         {
             regex: {


### PR DESCRIPTION
https://phabricator.endlessm.com/T20322