### PR TITLE
replacements: adjust for com.endlessm.Installer change

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -12,7 +12,7 @@ function generateEndlessInstallerEntry() {
     // If we detect the presence of com.endlessm.Installer.desktop, inform
     // the user on how to actually install Endless OS.
     let desktopInfo = Gio.DesktopAppInfo.new('com.endlessm.Installer.desktop');
-    if (desktopInfo) {
+    if (desktopInfo && !desktopInfo.get_nodisplay()) {
         entry.overrideHelpMessage = _("You are already running Endless OS from live media");
         entry.desktopInfo = desktopInfo,
         entry.replacementInfo = {


### PR DESCRIPTION
I've modified eos-installer to install its desktop file to the usual location, `/usr/share/applications`, but to set the `NoDisplay=true` key. On a live boot, this file is patched to remove that key.

This means that eos-gates cannot use the mere presence of the `com.endlessm.Installer.desktop` file as an indication that we're on a live system. Instead, check that it exists *and* that it does not have `NoDisplay=true` set.

The corresponding eos-installer change is in https://github.com/endlessm/eos-installer/pull/73.

https://phabricator.endlessm.com/T17082