### PR TITLE
Install Dropbox from flathub instead of eos-apps

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -63,7 +63,7 @@ function definitions() {
                  linux: /dropbox.*/i
             },
             appName: _("Dropbox"),
-            flatpakInfo: { remote: 'eos-apps', id: 'com.dropbox.Client' }
+            flatpakInfo: { remote: 'flathub', id: 'com.dropbox.Client' }
         },
         {
             regex: {


### PR DESCRIPTION
We are migrating Dropbox from eos-apps to flathub.

https://phabricator.endlessm.com/T23174#607442