### PR TITLE
replacements: add Scratch replacement

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -176,6 +176,13 @@ function definitions() {
             },
             appName: _("Minecraft"),
             flatpakInfo: { remote: 'flathub', id: 'com.mojang.Minecraft' }
+        },
+        {
+            regex: {
+                windows: /Scratch\sDesktop\sSetup\s.*\.(exe|msi)/i,
+            },
+            appName: _("Scratch"),
+            flatpakInfo: { remote: 'flathub', id: 'edu.mit.Scratch' }
         }
     ];
 }


### PR DESCRIPTION
Scratch is now available for download on Flathub.

https://phabricator.endlessm.com/T26658