### PR TITLE
Remove skip_taskbar_hint from window

### DIFF
--- a/src/eos_gates.js
+++ b/src/eos_gates.js
@@ -171,7 +171,6 @@ const Application = new Lang.Class({
     _buildUI: function() {
         this._window = new Gtk.ApplicationWindow({ application: this,
                                                    title: _("%s is unsupported").format(this.attempt.displayName),
-                                                   skip_taskbar_hint: true,
                                                    resizable: false,
                                                    width_request: 640,
                                                    height_request: 360 });


### PR DESCRIPTION
Previously, the window was not visible via Alt-Tab, via the Super-A or
hot-corner app switcher, or on the taskbar.

The taskbar icon is the "no icon" blue diamond with a cog – I think this
is better than nothing.

![eos-gates-icon](https://user-images.githubusercontent.com/86760/63650295-cc936180-c751-11e9-9d12-3b3c95a548f2.png)

https://phabricator.endlessm.com/T3946
