### PR TITLE
Explicitly require GTK 3

### DIFF
--- a/src/eos_gates.js
+++ b/src/eos_gates.js
@@ -4,6 +4,9 @@ const Gettext = imports.gettext;
 const Lang = imports.lang;
 const Signals = imports.signals;
 
+imports.gi.versions.Gtk = "3.0";
+imports.gi.versions.Gdk = "3.0";
+
 const Config = imports.config;
 const EosMetrics = imports.gi.EosMetrics;
 const Flatpak = imports.gi.Flatpak;

--- a/src/eos_gates_windows.js
+++ b/src/eos_gates_windows.js
@@ -3,7 +3,6 @@ const Lang = imports.lang;
 
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
 
 const EosGates = imports.eos_gates;
 const Replacements = imports.replacements;


### PR DESCRIPTION
Since we added gir1.2-gtk-4.0 and gir1.2-gdk-4.0 to the distro, Gates has picked the more recent, GTK/GDK 4, and crashed:

    Gjs-Message: 10:13:05.317: JS WARNING: [/usr/share/eos-gates/src/eos_gates_windows.js 6]: Requiring Gtk but it has 2 versions available; use imports.gi.versions to pick one

    (gjs-console:19895): Gjs-CRITICAL **: 10:13:05.368: JS ERROR: TypeError: Gdk.Screen is undefined
    vfunc_startup@/usr/share/eos-gates/src/eos_gates.js:238:9
    wrapper@resource:///org/gnome/gjs/modules/script/_legacy.js:83:27
    main@/usr/share/eos-gates/src/eos_gates_windows.js:119:9
    @<command line>:1:68

Do as the warning says, and pick GTK and GTK 3.

https://phabricator.endlessm.com/T33166
