### PR TITLE
replacements: Add Zoom

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -27,6 +27,14 @@ function definitions() {
     return [
         {
             regex: {
+                windows: /^zoom.*\.exe$/i,
+                linux: /^zoom/i
+            },
+            appName: _("Zoom"),
+            flatpakInfo: { remote: 'flathub', id: 'us.zoom.Zoom' }
+        },
+        {
+            regex: {
                 windows: /spotifysetup.*.exe/i
             },
             appName: _("Spotify"),


### PR DESCRIPTION
These patterns will match all attempts to launch Zoom that we have seen
in our metrics for the past 28 days, except for two attempts to launch
Baixaki_Zoom Meetings Para Windows_v3.889.482.80.8.exe.

https://phabricator.endlessm.com/T33341
