### PR TITLE
replacements: Update Scratch regex

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -212,7 +212,7 @@ function definitions() {
         },
         {
             regex: {
-                windows: /Scratch\sDesktop\sSetup\s.*\.(exe|msi)/i,
+                windows: /Scratch.*\sSetup\.(exe|msi)/i,
             },
             appName: _("Scratch"),
             flatpakInfo: { remote: 'flathub', id: 'edu.mit.Scratch' }


### PR DESCRIPTION
The current version of https://scratch.mit.edu provides downloads with names like "Scratch 3.29.1 Setup.exe".