### PR TITLE
meson: Use glib preset for i18n.gettext

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -1,1 +1,4 @@
-i18n.gettext(meson.project_name())
+i18n.gettext(
+    meson.project_name(),
+    preset: 'glib',
+)


### PR DESCRIPTION
The preset option is rather unhelpfully documented at
https://mesonbuild.com/i18n-module.html as follows:

> name of a preset list of arguments, current option is 'glib', see
> [source][] for their value

The really important option this adds is '--from-code=UTF-8' which tells
xgettext that our source code is in UTF-8, not ASCII. This fixes
generating the eos-gates.pot file, which was broken by
b32fcabfb26a03c61a6adde35f435d78103c26ca (“Relicense under GPL 3 or
later”) because I used an en-dash for the range of years.

[source]: https://github.com/mesonbuild/meson/blob/46b3c1c30df60f00c3505c802039407ebfb6f381/mesonbuild/modules/i18n.py#L83-L113

https://phabricator.endlessm.com/T35324
